### PR TITLE
build(deps): ➖ remove dependency: async_trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,7 +1519,6 @@ dependencies = [
 name = "rsjudge-judger"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "bytes",
  "futures",
  "rsjudge-traits",
@@ -1545,7 +1544,6 @@ name = "rsjudge-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "capctl",
  "libcgroups",
  "libseccomp",
@@ -1564,7 +1562,6 @@ dependencies = [
 name = "rsjudge-traits"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "indexmap 2.7.0",
  "serde",
  "serde_json",

--- a/crates/rsjudge-judger/Cargo.toml
+++ b/crates/rsjudge-judger/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait = "0.1.83"
 bytes = "1.9.0"
 futures = "0.3.31"
 rsjudge-traits.workspace = true

--- a/crates/rsjudge-judger/src/comparer/default_comparer.rs
+++ b/crates/rsjudge-judger/src/comparer/default_comparer.rs
@@ -4,7 +4,6 @@
 
 use std::io;
 
-use async_trait::async_trait;
 use futures::try_join;
 use rsjudge_utils::trim_space_end;
 use tokio::io::{AsyncBufReadExt as _, AsyncRead, BufReader};
@@ -72,7 +71,6 @@ impl Default for DefaultComparer {
     }
 }
 
-#[async_trait]
 impl Comparer for DefaultComparer {
     async fn compare<Out, Ans>(&self, out: Out, ans: Ans) -> io::Result<CompareResult>
     where

--- a/crates/rsjudge-judger/src/comparer/mod.rs
+++ b/crates/rsjudge-judger/src/comparer/mod.rs
@@ -2,9 +2,8 @@
 
 mod default_comparer;
 
-use std::io;
+use std::{future::Future, io};
 
-use async_trait::async_trait;
 use tokio::io::AsyncRead;
 
 pub use self::default_comparer::DefaultComparer;
@@ -16,9 +15,12 @@ pub enum CompareResult {
     PresentationError,
 }
 
-#[async_trait]
 pub trait Comparer {
-    async fn compare<Out, Ans>(&self, out: Out, ans: Ans) -> io::Result<CompareResult>
+    fn compare<Out, Ans>(
+        &self,
+        out: Out,
+        ans: Ans,
+    ) -> impl Future<Output = io::Result<CompareResult>> + Send
     where
         Out: AsyncRead + Send + Unpin,
         Ans: AsyncRead + Send + Unpin;

--- a/crates/rsjudge-runner/Cargo.toml
+++ b/crates/rsjudge-runner/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 description = "Command runner for rsjudge"
 
 [dependencies]
-async-trait = "0.1.83"
 capctl = "0.2.4"
 libcgroups = "0.4.1"
 libseccomp = { version = "0.3.0", features = ["const-syscall"] }

--- a/crates/rsjudge-runner/src/error.rs
+++ b/crates/rsjudge-runner/src/error.rs
@@ -24,10 +24,7 @@ pub enum Error {
     Io(std::io::Error),
 
     #[error("Time limit exceeded")]
-    TimeLimitExceeded(
-        #[cfg(debug_assertions)] Option<(ExitStatus, ResourceUsage)>,
-        #[cfg(not(debug_assertions))] (),
-    ),
+    TimeLimitExceeded(#[cfg(debug_assertions)] Option<(ExitStatus, ResourceUsage)>),
 
     #[error("Child process has exited with status: {0:?}")]
     ChildExited(ExitStatus),

--- a/crates/rsjudge-traits/Cargo.toml
+++ b/crates/rsjudge-traits/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait = "0.1.83"
 indexmap = { version = "2.7.0", features = ["serde"] }
 serde.workspace = true
 tokio = { workspace = true, features = ["process"] }

--- a/crates/rsjudge-traits/src/judger.rs
+++ b/crates/rsjudge-traits/src/judger.rs
@@ -2,14 +2,12 @@
 
 //! Abstraction for judger.
 
-use std::{path::Path, process::Output, time::Duration};
+use std::{future::Future, path::Path, process::Output, time::Duration};
 
-use async_trait::async_trait;
 use indexmap::IndexMap;
 
 use crate::language::{info::LanguageInfo, option::LanguageOption};
 
-#[async_trait]
 /// A trait for judging code.
 pub trait Judger {
     /// The error type of the judger.
@@ -19,23 +17,23 @@ pub trait Judger {
     fn accept_languages(&self) -> IndexMap<String, LanguageInfo>;
 
     /// Execute the code of the specified language, with the given input and time limit.
-    async fn exec(
+    fn exec(
         &self,
         lang: &LanguageOption,
         code: &str,
         input: &str,
         time_limit: Duration,
-    ) -> Result<Output, Self::Error>;
+    ) -> impl Future<Output = Result<Output, Self::Error>> + Send;
 
     /// Run the code of a specified language, with the given input and time limit, and compare the output with the answer.
-    async fn judge(
+    fn judge(
         &self,
         lang: &LanguageOption,
         code: &str,
         input_path: &Path,
         answer_path: &Path,
         time_limit: Duration,
-    ) -> Result<(Output, JudgeResult), Self::Error>;
+    ) -> impl Future<Output = Result<(Output, JudgeResult), Self::Error>> + Send;
 }
 
 #[derive(Debug)]

--- a/crates/rsjudge-traits/src/service.rs
+++ b/crates/rsjudge-traits/src/service.rs
@@ -2,7 +2,8 @@
 
 //! Abstraction for services.
 
-use async_trait::async_trait;
+use std::{error::Error, future::Future};
+
 use serde::de::DeserializeOwned;
 
 use crate::Judger;
@@ -10,19 +11,22 @@ use crate::Judger;
 /// A service for calling actions on [`Judger`].
 ///
 /// Can be a server, or a middleware fetching code from a message queue.
-#[async_trait]
 pub trait Service<J, C>
 where
     J: Judger,
     C: ServiceConfig,
 {
     /// Error type of the service.
-    type Error: std::error::Error;
+    type Error: Error;
 
     /// Start the service with the given judger and config.
-    async fn startup(&mut self, judger: J, config: C) -> Result<(), Self::Error>;
+    fn startup(
+        &mut self,
+        judger: J,
+        config: C,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
     /// Shutdown the service gracefully.
-    async fn shutdown(&mut self);
+    fn shutdown(&mut self) -> impl Future<Output = ()> + Send;
 }
 
 /// A trait for marking the service configuration.


### PR DESCRIPTION
`async-trait` is a dependency for compatibility with Rust versions earlier than 1.75, or allow async traits to be dyn-compatible. However, neither of these is needed for our project. It may lead to additional performance cost and make it difficult for developing.