### PR TITLE
build(msrv): ⬆️ bump MSRV to 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 repository = "https://github.com/NJUPT-SAST/rsjudge"
 
 # MSRV is set to N - 2, where N is the current stable version.
-rust-version = "1.79"
+rust-version = "1.81"
 
 [workspace.dependencies]
 log = "0.4.22"


### PR DESCRIPTION
Features from Rust [1.80](https://releases.rs/docs/1.80.0/) and [1.81](https://releases.rs/docs/1.81.0/) can be used now.

Some notable changes:

- `LazyCell` and `LazyLock` in 1.80.0
- `trim_ascii(_start,_end)` in 1.80.0
- `core::error` module in 1.81.0