### PR TITLE
ci(actions): 👷 use custom build of repo-visualizer

### DIFF
--- a/.github/workflows/visualize.yml
+++ b/.github/workflows/visualize.yml
@@ -11,6 +11,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
       - name: Update diagram
-        uses: hirako2000/repo-visualizer@main
+        uses: Jisu-Woniu/repo-visualizer@main
         with:
           branch: diagram


### PR DESCRIPTION
The original build of repo-visualizer creates lots of meaningless commits in the diagram branch, making the repository history hard to maintain.

In this commit, a custom build of repo-visualizer is used, which uses amend commit to make the history clean.
