### PR TITLE
ci(actions): 👷 use group configuration for dependabot so tonic-related packages are updated in a single commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    groups:
+      tonic:
+        patterns:
+          - "tonic*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/crates/rsjudge-amqp/Cargo.toml
+++ b/crates/rsjudge-amqp/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 [dependencies]
 amqprs = { version = "2.1.0", features = ["urispec"] }
 thiserror = "2.0.9"
-tokio = "1.42.0"
+tokio.workspace = true
 
 rsjudge-traits.workspace = true
 serde = { workspace = true, optional = true }


### PR DESCRIPTION
See <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups-->
