### PR TITLE
build(xtask): ➖ remove sh crate from xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [alias]
-xtask = "run --package xtask --"
-xtask-dbg = "run --package xtask --features dbg --"
+xtask = "run --package xtask --locked --"
+xtask-dbg = "run --package xtask --features dbg --locked --"
 
-# Use custom linker for faster linking
+# # Use custom linker for faster linking
 # [build]
 # rustflags = ["-Clink-arg=-fuse-ld=mold"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "shlex",
 ]
@@ -831,18 +831,9 @@ checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "litrs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
-dependencies = [
- "proc-macro2",
-]
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -996,18 +987,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1016,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1043,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1246,7 +1237,7 @@ dependencies = [
  "amqprs",
  "rsjudge-traits",
  "serde",
- "thiserror 2.0.9",
+ "thiserror",
  "tokio",
 ]
 
@@ -1304,7 +1295,7 @@ dependencies = [
  "rsjudge-traits",
  "rsjudge-utils",
  "rustversion",
- "thiserror 2.0.9",
+ "thiserror",
  "tokio",
  "tokio-util",
  "uzers",
@@ -1328,7 +1319,7 @@ dependencies = [
  "anyhow",
  "log",
  "shell-words",
- "thiserror 2.0.9",
+ "thiserror",
  "tokio",
 ]
 
@@ -1340,9 +1331,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -1451,27 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sh"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40748b229ba0f836ef0d162b4f479b7adc660494bb89c527dafaa7e98f9eb5a2"
-dependencies = [
- "sh-macro",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sh-macro"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16da17e38a2b1390a7ca0ec7251369bf0e06726ebb7df0a0236d3e90cbdf8384"
-dependencies = [
- "litrs",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,9 +1495,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.94"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1571,31 +1541,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.9",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2033,9 +1983,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]
@@ -2046,7 +1996,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "sh",
 ]
 
 [[package]]

--- a/dprint.json
+++ b/dprint.json
@@ -19,8 +19,8 @@
   "plugins": [
     "https://plugins.dprint.dev/json-0.19.4.wasm",
     "https://plugins.dprint.dev/markdown-0.17.8.wasm",
-    "https://plugins.dprint.dev/toml-0.6.3.wasm",
-    "https://plugins.dprint.dev/exec-0.5.0.json@8d9972eee71fa1590e04873540421f3eda7674d0f1aae3d7c788615e7b7413d0",
+    "https://plugins.dprint.dev/toml-0.6.4.wasm",
+    "https://plugins.dprint.dev/exec-0.5.1.json@492414e39dea4dccc07b4af796d2f4efdb89e84bae2bd4e1e924c0cc050855bf",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
   ]
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,7 +13,6 @@ description = "A task runner for cargo workspaces"
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.24", features = ["derive"] }
-sh = "0.2.1"
 
 [features]
 dbg = []

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env::set_current_dir, path::Path};
+use std::{env::set_current_dir, io, path::Path, process::Command};
 
 use clap::{Parser, ValueEnum};
-use sh::cmd;
 
 #[derive(Debug, ValueEnum, Clone, Copy, PartialEq, Eq)]
 /// Package distribution-specific packages.
@@ -17,12 +16,12 @@ enum Package {
 #[derive(Debug, Parser)]
 #[clap(about, long_about)]
 /// Build related tasks.
-enum Command {
+enum Args {
     /// Package distribution-specific packages.
     Dist {
         /// Which package to build.
         #[arg(value_enum)]
-        package: Package,
+        pkg: Package,
     },
     /// Build Docker image.
     Docker,
@@ -31,30 +30,28 @@ enum Command {
     Debug,
 }
 
+fn exec(program: &str, args: &[&str]) -> io::Result<()> {
+    Command::new(program).args(args).spawn()?.wait()?;
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
-    let command = Command::parse();
+    let args = Args::parse();
 
     // chdir to the workspace root so that `cargo xtask` can be invoked from anywhere.
     set_current_dir(Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap())?;
 
-    match command {
-        Command::Dist { package } => match package {
-            Package::Deb => cmd!(cargo deb "-v" "--locked"),
-            Package::Rpm => cmd! {
-                cargo build "--release" "--locked";
-                cargo "generate-rpm"
-            },
-        },
-        Command::Docker => cmd!(docker build "-t" rsjudge "."),
-
+    match args {
+        Args::Dist { pkg: Package::Deb } => exec("cargo", &["deb", "-v", "--locked"])?,
+        Args::Dist { pkg: Package::Rpm } => {
+            // `cargo-generate-rpm` does not invoke `cargo build` itself.
+            exec("cargo", &["build", "--release", "--locked"])?;
+            exec("cargo", &["generate-rpm"])?;
+        }
+        Args::Docker => exec("docker", &["build", "-t", "rsjudge", "."])?,
         #[cfg(feature = "dbg")]
-        Command::Debug => return Ok(()),
+        Args::Debug => {}
     }
-    .try_for_each(|cmd| {
-        #[cfg(feature = "dbg")]
-        eprintln!("Executing: {:?}", cmd);
-        cmd.exec()
-    })?;
 
     Ok(())
 }


### PR DESCRIPTION
The syntax of `sh` crate is odd, and most of the usage in `xtask` can be replaced with simple [`Command`] operations.

As `sh` is not updated regularly (the latest commit is 9 months ago), it is natural to remove it from dependencies.

[`Command`]: https://doc.rust-lang.org/stable/std/process/struct.Command.html
