### PR TITLE
build(msrv): ⬆️ bump MSRV to 1.82

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,9 +381,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbfe6ac42a2438d0968beba18e3c35cacf16b0c25310bc22b1f5f3cffff09f4"
+checksum = "724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a"
 dependencies = [
  "clap",
  "roff",
@@ -1495,9 +1495,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1541,18 +1541,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 repository = "https://github.com/NJUPT-SAST/rsjudge"
 
 # MSRV is set to N - 2, where N is the current stable version.
-rust-version = "1.81"
+rust-version = "1.82"
 
 [workspace.dependencies]
 log = "0.4.22"
@@ -170,7 +170,7 @@ tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros", "proc
 toml = "0.8.19"
 
 # Unused for now:
-# nix = { version = "0.27.1", features = ["fs"] }
+# nix = { version = "0.29.0", features = ["fs"] }
 # strfmt = "0.2.4"
 
 [features]
@@ -183,7 +183,7 @@ default = ["grpc", "rest", "mimalloc"]
 [build-dependencies]
 clap = { version = "4.5.26", features = ["derive"] }
 clap_complete = "4.5.42"
-clap_mangen = "0.2.25"
+clap_mangen = "0.2.26"
 
 [profile.release]
 codegen-units = 1

--- a/crates/rsjudge-amqp/Cargo.toml
+++ b/crates/rsjudge-amqp/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 
 [dependencies]
 amqprs = { version = "2.1.0", features = ["urispec"] }
-thiserror = "2.0.10"
+thiserror = "2.0.11"
 tokio.workspace = true
 
 rsjudge-traits.workspace = true

--- a/crates/rsjudge-runner/Cargo.toml
+++ b/crates/rsjudge-runner/Cargo.toml
@@ -17,7 +17,7 @@ log.workspace = true
 nix = { version = "0.29.0", features = ["user", "resource", "process"] }
 rsjudge-traits.workspace = true
 rsjudge-utils.workspace = true
-thiserror = "2.0.10"
+thiserror = "2.0.11"
 tokio = { workspace = true, features = ["process", "sync", "time", "signal"] }
 tokio-util = "0.7.13"
 uzers = "0.12.1"

--- a/crates/rsjudge-runner/src/utils/resources/rusage.rs
+++ b/crates/rsjudge-runner/src/utils/resources/rusage.rs
@@ -2,7 +2,7 @@
 
 use std::{
     future::Future, io, mem::MaybeUninit, os::unix::process::ExitStatusExt, process::ExitStatus,
-    ptr::addr_of_mut, time::Duration,
+    time::Duration,
 };
 
 use nix::{
@@ -93,7 +93,7 @@ pub fn wait4<P: Into<Option<Pid>>>(
         let res = unsafe {
             libc::wait4(
                 pid.unwrap_or_else(|| Pid::from_raw(-1)).into(),
-                addr_of_mut!(status),
+                &raw mut status,
                 option_bits,
                 rusage.as_mut_ptr(),
             )

--- a/crates/rsjudge-utils/Cargo.toml
+++ b/crates/rsjudge-utils/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 [dependencies]
 log.workspace = true
 shell-words = "1.1.0"
-thiserror = "2.0.10"
+thiserror = "2.0.11"
 tokio = { workspace = true, features = ["process", "macros", "rt-multi-thread"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Features from Rust 1.82 can be used now.

Notable changes:

- [`&raw (const|mut)` for extract raw pointer from a reference](https://github.com/rust-lang/rust/pull/127679)