### PR TITLE
ci(actions): 💚 do not cache the nightly toolchain

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           channel: nightly
           components: rustfmt
+          cache: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check code format with dprint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1187,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -1427,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -1483,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1578,9 +1578,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1862,9 +1862,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "uriparse"

--- a/crates/rsjudge-judger/Cargo.toml
+++ b/crates/rsjudge-judger/Cargo.toml
@@ -18,6 +18,6 @@ serde.workspace = true
 tokio = { workspace = true, features = ["io-util", "fs", "macros"] }
 
 [dev-dependencies]
-serde_json = "1.0.139"
+serde_json = "1.0.140"
 tempfile = "3.17.1"
 tokio = { workspace = true, features = ["rt-multi-thread", "full"] }

--- a/crates/rsjudge-runner/Cargo.toml
+++ b/crates/rsjudge-runner/Cargo.toml
@@ -29,4 +29,4 @@ uzers = "0.12.1"
 anyhow = "1.0.97"
 
 [build-dependencies]
-rustversion = "1.0.19"
+rustversion = "1.0.20"

--- a/crates/rsjudge-traits/Cargo.toml
+++ b/crates/rsjudge-traits/Cargo.toml
@@ -15,5 +15,5 @@ serde.workspace = true
 tokio = { workspace = true, features = ["process"] }
 
 [dev-dependencies]
-serde_json = "1.0.139"
+serde_json = "1.0.140"
 toml = { version = "0.8.20", features = ["preserve_order"] }


### PR DESCRIPTION
Nightly version of Rust toolchain gets updates frequently. It is not meant to be cached.
