### PR TITLE
style: 🎨 enforce comment style

### DIFF
--- a/crates/rsjudge-grpc/build.rs
+++ b/crates/rsjudge-grpc/build.rs
@@ -8,8 +8,8 @@ use tonic_build::configure;
 
 /// Generate Rust code from the proto files.
 ///
-/// The build script uses `buf` to list all the proto files in the `proto` directory and then
-/// compiles them using `tonic_build`.
+/// The build script uses `buf` to list all the proto files in the `proto`
+/// directory and then compiles them using `tonic_build`.
 ///
 /// `buf` is needed to run this build script.
 #[tokio::main]

--- a/crates/rsjudge-grpc/src/lib.rs
+++ b/crates/rsjudge-grpc/src/lib.rs
@@ -16,6 +16,8 @@ mod server;
 ///
 /// # Errors
 ///
+/// This will error when the server fails to start or when the address is
+/// invalid.
 pub async fn serve(addr: SocketAddr) -> Result<(), Error> {
     Server::builder()
         .add_service(JudgeServiceServer::new(JudgeServerImpl))

--- a/crates/rsjudge-judger/src/comparer/default_comparer.rs
+++ b/crates/rsjudge-judger/src/comparer/default_comparer.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! A default comparer implementation, supporting ignoring trailing whitespace and/or trailing newline.
+//! A default comparer implementation, supporting ignoring trailing whitespace
+//! and/or trailing newline.
 
 use std::io;
 

--- a/crates/rsjudge-rest/src/lib.rs
+++ b/crates/rsjudge-rest/src/lib.rs
@@ -11,6 +11,8 @@ use tokio::net::TcpListener;
 ///
 /// # Errors
 ///
+/// This will error when the server fails to start or when the address is
+/// invalid.
 pub async fn serve(addr: SocketAddr) -> io::Result<()> {
     let app = Router::new().route("/", get(|| async { "Hello, World!" }));
     let listener = TcpListener::bind(addr).await?;

--- a/crates/rsjudge-runner/src/error.rs
+++ b/crates/rsjudge-runner/src/error.rs
@@ -41,7 +41,8 @@ pub enum Error {
     AlreadyExited,
 }
 
-/// Convert any error implementing [`Into`]`<`[`io::Error`]`>` into [`enum@Error`].
+/// Convert any error implementing [`Into`]`<`[`io::Error`]`>` into
+/// [`enum@Error`].
 impl<E: Into<io::Error>> From<E> for Error {
     fn from(value: E) -> Self {
         Self::Io(value.into())

--- a/crates/rsjudge-runner/src/macros.rs
+++ b/crates/rsjudge-runner/src/macros.rs
@@ -4,8 +4,8 @@
 /// Use capabilities in the current thread, in a declarative way.
 ///
 /// Mind that this macro does not emit an expression, but a statement.
-/// And it must be used inside a function returning [`rsjudge_runner::Result`][crate::Result]
-/// or a compatible type.
+/// And it must be used inside a function returning
+/// [`rsjudge_runner::Result`][crate::Result] or a compatible type.
 macro_rules! use_caps {
     ($($cap:expr),* $(,)?) => {
         let handle = [$($crate::CapHandle::new($cap)?),*];

--- a/crates/rsjudge-runner/src/run_as.rs
+++ b/crates/rsjudge-runner/src/run_as.rs
@@ -18,7 +18,8 @@ pub trait RunAs {
 
     /// Run the [`Command`] as the given [`User`].
     ///
-    /// This function will set the UID, GID, and supplementary groups of the command.
+    /// This function will set the UID, GID, and supplementary groups of the
+    /// command.
     ///
     /// # Errors
     ///

--- a/crates/rsjudge-runner/src/user.rs
+++ b/crates/rsjudge-runner/src/user.rs
@@ -2,7 +2,8 @@
 
 //! Functions to get user instances.
 //!
-//! All functions return a reference to a static instance of [`uzers::User`] if succeeded.
+//! All functions return a reference to a static instance of [`uzers::User`] if
+//! succeeded.
 
 use std::sync::LazyLock;
 

--- a/crates/rsjudge-runner/src/utils/cap_handle.rs
+++ b/crates/rsjudge-runner/src/utils/cap_handle.rs
@@ -18,13 +18,16 @@ struct NonCopy;
 
 /// An RAII-style handle for capabilities.
 ///
-/// When constructed, the handle will raise the capability if it is permitted but not effective.
+/// When constructed, the handle will raise the capability if it is permitted
+/// but not effective.
 ///
-/// When dropped, the handle will drop the capability if it is the last reference.
+/// When dropped, the handle will drop the capability if it is the last
+/// reference.
 ///
 /// # Note
 ///
-/// You can use [`use_caps!`][crate::use_caps] macro to simplify the usage of this struct.
+/// You can use [`use_caps!`][crate::use_caps] macro to simplify the usage of
+/// this struct.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct CapHandle {
     cap: Cap,

--- a/crates/rsjudge-runner/src/utils/resources/mod.rs
+++ b/crates/rsjudge-runner/src/utils/resources/mod.rs
@@ -44,14 +44,16 @@ impl CommandWithResourceLimit {
 
 /// Setting resource limits for a [`Command`].
 ///
-/// This will take the [`Command`] by value and set the [`ResourceLimit`] for it.
+/// This will take the [`Command`] by value and set the [`ResourceLimit`] for
+/// it.
 pub trait WithResourceLimit {
     /// Register resource limit for the command.
     ///
     /// Returns a [`CommandWithResourceLimit`] which can be spawned.
     ///
-    /// You can also use [`command`][fn.command] or [`command_mut`][fn.command_mut]
-    /// to get the inner [`Command`] object as needed.
+    /// You can also use [`command`][fn.command] or
+    /// [`command_mut`][fn.command_mut] to get the inner [`Command`] object
+    /// as needed.
     ///
     /// [fn.command]: CommandWithResourceLimit::command
     /// [fn.command_mut]: CommandWithResourceLimit::command_mut
@@ -61,13 +63,15 @@ pub trait WithResourceLimit {
     /// This function won't wait for the child to exit.
     /// Nor will it apply the [`ResourceLimit::wall_time_limit`] automatically.
     ///
-    /// However, the wall time limit can be applied by using [`wait_for_resource_usage`].
+    /// However, the wall time limit can be applied by using
+    /// [`wait_for_resource_usage`].
     ///
     /// This function is synchronous.
     ///
     /// # Errors
     ///
-    /// This function will return an error if the child process cannot be spawned.
+    /// This function will return an error if the child process cannot be
+    /// spawned.
     ///
     /// [`wait_for_resource_usage`]: WaitForResourceUsage::wait_for_resource_usage
     fn spawn_with_resource_limit(self, resource_limit: ResourceLimit) -> Result<ChildWithDeadline>;

--- a/crates/rsjudge-runner/src/utils/resources/rusage.rs
+++ b/crates/rsjudge-runner/src/utils/resources/rusage.rs
@@ -63,7 +63,8 @@ impl ResourceUsage {
 pub trait WaitForResourceUsage {
     /// Wait for the resource usage of the process.
     ///
-    /// Uses wait4(2) internally to wait for the process to exit and get the resource usage.
+    /// Uses wait4(2) internally to wait for the process to exit and get the
+    /// resource usage.
     ///
     /// See [`wait4`]
     fn wait_for_resource_usage(
@@ -81,8 +82,9 @@ pub trait WaitForResourceUsage {
 ///
 /// # Note
 ///
-/// If you have already run this function on a [`Child`]'s PID and got a result of `Some`,
-/// *DO NOT RUN* `wait`, `try_wait`, etc. again on the `Child`, or you will get an errno of `ECHILD`.
+/// If you have already run this function on a [`Child`]'s PID and got a result
+/// of `Some`, *DO NOT RUN* `wait`, `try_wait`, etc. again on the `Child`, or
+/// you will get an errno of `ECHILD`.
 ///
 /// [wait4(2)]: https://man7.org/linux/man-pages/man2/wait4.2.html
 pub fn wait4<P: Into<Option<Pid>>>(

--- a/crates/rsjudge-traits/src/judger.rs
+++ b/crates/rsjudge-traits/src/judger.rs
@@ -16,7 +16,8 @@ pub trait Judger {
     /// Get a list of all supported languages.
     fn accept_languages(&self) -> IndexMap<String, LanguageInfo>;
 
-    /// Execute the code of the specified language, with the given input and time limit.
+    /// Execute the code of the specified language, with the given input and
+    /// time limit.
     fn exec(
         &self,
         lang: &LanguageOption,
@@ -25,7 +26,8 @@ pub trait Judger {
         time_limit: Duration,
     ) -> impl Future<Output = Result<Output, Self::Error>> + Send;
 
-    /// Run the code of a specified language, with the given input and time limit, and compare the output with the answer.
+    /// Run the code of a specified language, with the given input and time
+    /// limit, and compare the output with the answer.
     fn judge(
         &self,
         lang: &LanguageOption,

--- a/crates/rsjudge-traits/src/language/config.rs
+++ b/crates/rsjudge-traits/src/language/config.rs
@@ -25,7 +25,8 @@ pub enum ExecType {
         /// Compilation command for the language.
         compile: String,
     },
-    /// The language is compiled to an intermediate representation, which is then executed with another command.
+    /// The language is compiled to an intermediate representation, which is
+    /// then executed with another command.
     ByteCode {
         /// Compilation command for the language.
         compile: String,
@@ -47,7 +48,8 @@ pub enum ExecType {
 pub enum ConfigDef {
     /// A boolean configuration.
     Bool {
-        /// Where to put the `enable` value. Often a variable in compilation or execution command.
+        /// Where to put the `enable` value. Often a variable in compilation or
+        /// execution command.
         target: String,
         /// Default value of the configuration.
         default: bool,

--- a/crates/rsjudge-traits/src/resource.rs
+++ b/crates/rsjudge-traits/src/resource.rs
@@ -13,7 +13,8 @@ pub struct ResourceLimit {
     ///
     /// # Note
     ///
-    /// Wall time limit may be inaccurate, due to the implementation of "wait-and-check" strategy.
+    /// Wall time limit may be inaccurate, due to the implementation of
+    /// "wait-and-check" strategy.
     wall_time_limit: Option<Duration>,
     /// The memory limit **in bytes**.
     memory_limit: Option<NonZeroU64>,

--- a/crates/rsjudge-utils/src/command.rs
+++ b/crates/rsjudge-utils/src/command.rs
@@ -61,7 +61,8 @@ pub enum ExecutionError {
 impl ExecutionError {
     /// Get the output of the command, if any.
     ///
-    /// This method will return `Some(&Output)` if the error is `NonZeroExitStatus`, otherwise `None`.
+    /// This method will return `Some(&Output)` if the error is
+    /// `NonZeroExitStatus`, otherwise `None`.
     #[must_use]
     pub fn output(&self) -> Option<&Output> {
         match self {
@@ -98,8 +99,8 @@ impl ExecutionError {
 ///
 /// # Errors
 ///
-/// This function returns an error if the command was not found, failed to start,
-/// or failed with a non-zero exit status.
+/// This function returns an error if the command was not found, failed to
+/// start, or failed with a non-zero exit status.
 pub async fn check_output(cmd: &mut Command) -> Result<Output, ExecutionError> {
     let child = cmd
         .stdout(Stdio::piped())

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,3 +5,4 @@ style_edition = "2024"
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
 unstable_features = true
+wrap_comments = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ use crate::cli::Args;
 mod cli;
 mod config;
 
-/// Main Entry point. This function assumes the global logger is correctly setup.
+/// Main Entry point. This function assumes the global logger is correctly
+/// setup.
 ///
 /// # Errors
 ///

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -38,7 +38,8 @@ fn exec(program: &str, args: &[&str]) -> io::Result<()> {
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    // chdir to the workspace root so that `cargo xtask` can be invoked from anywhere.
+    // chdir to the workspace root so that `cargo xtask` can be invoked from
+    // anywhere.
     set_current_dir(Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap())?;
 
     match args {


### PR DESCRIPTION
As mentioned by Rust Style Guide:

> Source lines which are entirely a comment should be limited to 80 characters in length (including comment sigils, but excluding indentation) or the maximum width of the line (including comment sigils and indentation), whichever is smaller.

We use [`wrap_comments` from rustfmt](https://rust-lang.github.io/rustfmt/#wrap_comments) to enforce this.