### PR TITLE
Potential fix for code scanning alert no. 183: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   merge_group:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -27,6 +30,9 @@ jobs:
         uses: dprint/check@v2.2
   lint-debug:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Optimize APT
@@ -121,6 +127,9 @@ jobs:
         run: cargo deny --all-features --workspace check
   lint-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Optimize APT


### PR DESCRIPTION
Potential fix for [https://github.com/NJUPT-SAST/rsjudge/security/code-scanning/183](https://github.com/NJUPT-SAST/rsjudge/security/code-scanning/183)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for the workflow. Based on the provided workflow, most steps involve reading repository contents, so we will set `contents: read` as the default permission. If specific jobs require additional permissions, we will define them explicitly within those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
