### PR TITLE
Potential fix for code scanning alert no. 177: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/visualize.yml
+++ b/.github/workflows/visualize.yml
@@ -1,4 +1,6 @@
 name: Create diagram
+permissions:
+  contents: write
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/NJUPT-SAST/rsjudge/security/code-scanning/177](https://github.com/NJUPT-SAST/rsjudge/security/code-scanning/177)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it appears that the `contents: write` permission is necessary for the `Jisu-Woniu/repo-visualizer` action to update the diagram and commit changes to the repository. All other permissions will be omitted to minimize the scope of access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
