### PR TITLE
build(msrv): ⬆ bump MSRV to 1.85, edition 2024

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
         with:
-          channel: "1.84"
+          channel: "1.85"
           bins: cargo-hack, cargo-nextest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "rsjudge"
 version.workspace = true
 authors.workspace = true
-edition = "2021"
+edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
@@ -24,11 +24,11 @@ members = [
 [workspace.package]
 version = "0.1.0"
 authors = ["NJUPT-SAST"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NJUPT-SAST/rsjudge"
 # MSRV is set to N - 2, where N is the current stable version.
-rust-version = "1.84"
+rust-version = "1.85"
 
 [workspace.dependencies]
 log = "0.4.27"

--- a/dprint.json
+++ b/dprint.json
@@ -23,6 +23,6 @@
     "https://plugins.dprint.dev/markdown-0.18.0.wasm",
     "https://plugins.dprint.dev/toml-0.7.0.wasm",
     "https://plugins.dprint.dev/exec-0.5.1.json@492414e39dea4dccc07b4af796d2f4efdb89e84bae2bd4e1e924c0cc050855bf",
-    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
   ]
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-edition = "2021"
-style_edition = "2024"
+edition = "2024"
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
 unstable_features = true


### PR DESCRIPTION
Features of Rust 1.85 & edition 2024 can be used now.

Closes #245 #246 #247
