### PR TITLE
style(config): 🔧 use `imports_granularity = "Module"` as rust-lang/rust do

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,15 +3,14 @@
 #[path = "src/cli.rs"]
 mod cli;
 
-use std::{
-    env::var_os,
-    fs::{File, create_dir_all},
-    io::{self, Write},
-    path::Path,
-};
+use std::env::var_os;
+use std::fs::{File, create_dir_all};
+use std::io::{self, Write};
+use std::path::Path;
 
 use clap::CommandFactory;
-use clap_complete::{generate_to, shells::Shell};
+use clap_complete::generate_to;
+use clap_complete::shells::Shell;
 use clap_mangen::Man;
 
 use crate::cli::Args;

--- a/crates/rsjudge-amqp/src/lib.rs
+++ b/crates/rsjudge-amqp/src/lib.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use amqprs::{
-    callbacks::{DefaultChannelCallback, DefaultConnectionCallback},
-    connection::{Connection, OpenConnectionArguments},
-};
+use amqprs::callbacks::{DefaultChannelCallback, DefaultConnectionCallback};
+use amqprs::connection::{Connection, OpenConnectionArguments};
 
 use crate::config::AmqpConfig;
 pub use crate::error::{Error, Result};

--- a/crates/rsjudge-grpc/build.rs
+++ b/crates/rsjudge-grpc/build.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, io::BufRead, path::PathBuf};
+use std::env;
+use std::io::BufRead;
+use std::path::PathBuf;
 
 use rsjudge_utils::command::check_output;
 use tokio::process::Command;

--- a/crates/rsjudge-grpc/src/lib.rs
+++ b/crates/rsjudge-grpc/src/lib.rs
@@ -6,7 +6,8 @@ use std::net::SocketAddr;
 
 use tonic::transport::{Error, Server};
 
-use crate::{proto::judge_service_server::JudgeServiceServer, server::JudgeServerImpl};
+use crate::proto::judge_service_server::JudgeServiceServer;
+use crate::server::JudgeServerImpl;
 
 pub mod config;
 mod proto;

--- a/crates/rsjudge-grpc/src/server.rs
+++ b/crates/rsjudge-grpc/src/server.rs
@@ -4,10 +4,8 @@ use log::debug;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, async_trait};
 
-use crate::proto::{
-    SelfTestRequest, SelfTestResponse, SubmitRequest, SubmitResponse,
-    judge_service_server::JudgeService,
-};
+use crate::proto::judge_service_server::JudgeService;
+use crate::proto::{SelfTestRequest, SelfTestResponse, SubmitRequest, SubmitResponse};
 
 #[derive(Debug, Default)]
 pub struct JudgeServerImpl;

--- a/crates/rsjudge-judger/src/comparer/default_comparer.rs
+++ b/crates/rsjudge-judger/src/comparer/default_comparer.rs
@@ -117,10 +117,8 @@ mod tests {
     use std::io;
 
     use tempfile::TempDir;
-    use tokio::{
-        fs::File,
-        io::{AsyncWriteExt as _, empty},
-    };
+    use tokio::fs::File;
+    use tokio::io::{AsyncWriteExt as _, empty};
 
     use crate::comparer::{CompareResult, Comparer as _, DefaultComparer};
 

--- a/crates/rsjudge-judger/src/comparer/mod.rs
+++ b/crates/rsjudge-judger/src/comparer/mod.rs
@@ -2,7 +2,8 @@
 
 mod default_comparer;
 
-use std::{future::Future, io};
+use std::future::Future;
+use std::io;
 
 use tokio::io::AsyncRead;
 

--- a/crates/rsjudge-judger/src/judger/request/cases.rs
+++ b/crates/rsjudge-judger/src/judger/request/cases.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{num::NonZeroU32, path::PathBuf};
+use std::num::NonZeroU32;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/rsjudge-judger/src/judger/request/mod.rs
+++ b/crates/rsjudge-judger/src/judger/request/mod.rs
@@ -2,7 +2,8 @@
 
 use bytes::Bytes;
 
-use crate::judger::request::{cases::CasesConfig, source::Source};
+use crate::judger::request::cases::CasesConfig;
+use crate::judger::request::source::Source;
 
 mod source;
 

--- a/crates/rsjudge-rest/src/lib.rs
+++ b/crates/rsjudge-rest/src/lib.rs
@@ -2,9 +2,11 @@
 
 pub mod config;
 
-use std::{io, net::SocketAddr};
+use std::io;
+use std::net::SocketAddr;
 
-use axum::{Router, routing::get};
+use axum::Router;
+use axum::routing::get;
 use tokio::net::TcpListener;
 
 /// Serve the REST API at the given address.

--- a/crates/rsjudge-runner/examples/cap_test.rs
+++ b/crates/rsjudge-runner/examples/cap_test.rs
@@ -3,7 +3,8 @@
 use std::path::PathBuf;
 
 use capctl::{Cap, CapState};
-use rsjudge_runner::{RunAs, use_caps, user::builder};
+use rsjudge_runner::user::builder;
+use rsjudge_runner::{RunAs, use_caps};
 use rsjudge_utils::command::check_output;
 use tokio::process::Command;
 

--- a/crates/rsjudge-runner/examples/get_user_info.rs
+++ b/crates/rsjudge-runner/examples/get_user_info.rs
@@ -2,10 +2,8 @@
 
 use anyhow::anyhow;
 use capctl::Cap;
-use rsjudge_runner::{
-    RunAs, use_caps,
-    user::{builder, runner},
-};
+use rsjudge_runner::user::{builder, runner};
+use rsjudge_runner::{RunAs, use_caps};
 use tokio::process::Command;
 use uzers::{get_current_uid, get_user_by_uid};
 

--- a/crates/rsjudge-runner/examples/rusage_test.rs
+++ b/crates/rsjudge-runner/examples/rusage_test.rs
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{num::NonZeroU64, os::unix::process::ExitStatusExt, path::PathBuf, time::Duration};
+use std::num::NonZeroU64;
+use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::bail;
-use nix::{sys::wait::WaitStatus, unistd::Pid};
-use rsjudge_runner::utils::resources::{WithResourceLimit as _, rusage::WaitForResourceUsage};
+use nix::sys::wait::WaitStatus;
+use nix::unistd::Pid;
+use rsjudge_runner::utils::resources::WithResourceLimit as _;
+use rsjudge_runner::utils::resources::rusage::WaitForResourceUsage;
 use rsjudge_traits::resource::ResourceLimit;
-use tokio::{process::Command, time::Instant};
+use tokio::process::Command;
+use tokio::time::Instant;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/crates/rsjudge-runner/examples/sleep.rs
+++ b/crates/rsjudge-runner/examples/sleep.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{thread::sleep, time::Duration};
+use std::thread::sleep;
+use std::time::Duration;
 
 fn main() {
     println!("Trying to sleep for 10s.");

--- a/crates/rsjudge-runner/src/error.rs
+++ b/crates/rsjudge-runner/src/error.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Cow;
+use std::io;
 #[cfg(debug_assertions)]
 use std::process::ExitStatus;
-use std::{borrow::Cow, io, result::Result as StdResult};
+use std::result::Result as StdResult;
 
 use capctl::Cap;
 use log::error;

--- a/crates/rsjudge-runner/src/lib.rs
+++ b/crates/rsjudge-runner/src/lib.rs
@@ -3,10 +3,8 @@
 #![cfg_attr(not(test), warn(clippy::print_stdout, clippy::print_stderr))]
 #![cfg_attr(feature = "setgroups", feature(setgroups))]
 
-pub use crate::{
-    error::{Error, Result},
-    utils::cap_handle::{Cap, CapHandle},
-};
+pub use crate::error::{Error, Result};
+pub use crate::utils::cap_handle::{Cap, CapHandle};
 
 mod error;
 

--- a/crates/rsjudge-runner/src/run_as.rs
+++ b/crates/rsjudge-runner/src/run_as.rs
@@ -7,10 +7,8 @@ use rsjudge_utils::log_if_error;
 use tokio::process::Command;
 use uzers::User;
 
-use crate::{
-    error::{Error, Result},
-    utils::cap_handle::CapHandle,
-};
+use crate::error::{Error, Result};
+use crate::utils::cap_handle::CapHandle;
 
 /// A trait to allow running a [`tokio::process::Command`] as another user.
 pub trait RunAs {

--- a/crates/rsjudge-runner/src/utils/cap_handle.rs
+++ b/crates/rsjudge-runner/src/utils/cap_handle.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! RAII-style Capability handle.
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    rc::{Rc, Weak},
-};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::{Rc, Weak};
 
 pub use capctl::Cap;
 use capctl::CapState;
 use rsjudge_utils::log_if_error;
 
-use crate::{Result, error::CapRequiredError};
+use crate::Result;
+use crate::error::CapRequiredError;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 struct NonCopy;

--- a/crates/rsjudge-runner/src/utils/resources/mod.rs
+++ b/crates/rsjudge-runner/src/utils/resources/mod.rs
@@ -2,14 +2,14 @@
 
 pub mod rusage;
 
-use std::{future::Future, process::ExitStatus, time::Duration};
+use std::future::Future;
+use std::process::ExitStatus;
+use std::time::Duration;
 
 use nix::sys::resource::{Resource, setrlimit};
 use rsjudge_traits::resource::ResourceLimit;
-use tokio::{
-    process::{Child, Command},
-    time::Instant,
-};
+use tokio::process::{Child, Command};
+use tokio::time::Instant;
 
 use self::rusage::{ResourceUsage, WaitForResourceUsage};
 use crate::Result;
@@ -171,10 +171,9 @@ mod tests {
 
     use rsjudge_traits::resource::ResourceLimit;
 
-    use crate::{
-        Error,
-        utils::resources::{WithResourceLimit as _, rusage::WaitForResourceUsage as _},
-    };
+    use crate::Error;
+    use crate::utils::resources::WithResourceLimit as _;
+    use crate::utils::resources::rusage::WaitForResourceUsage as _;
 
     #[tokio::test]
     async fn test_wait_for_resource_usage() {

--- a/crates/rsjudge-runner/src/utils/resources/rusage.rs
+++ b/crates/rsjudge-runner/src/utils/resources/rusage.rs
@@ -1,21 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    future::Future, io, mem::MaybeUninit, os::unix::process::ExitStatusExt, process::ExitStatus,
-    time::Duration,
-};
+use std::future::Future;
+use std::io;
+use std::mem::MaybeUninit;
+use std::os::unix::process::ExitStatusExt;
+use std::process::ExitStatus;
+use std::time::Duration;
 
-use nix::{
-    errno::Errno,
-    libc::{self, rusage},
-    sys::wait::WaitPidFlag,
-    unistd::Pid,
-};
-use tokio::{
-    process::Child,
-    signal::unix::{SignalKind, signal},
-    time::timeout_at,
-};
+use nix::errno::Errno;
+use nix::libc::{self, rusage};
+use nix::sys::wait::WaitPidFlag;
+use nix::unistd::Pid;
+use tokio::process::Child;
+use tokio::signal::unix::{SignalKind, signal};
+use tokio::time::timeout_at;
 
 // use tokio_util::sync::CancellationToken;
 use crate::{Error, Result, utils::resources::ChildWithDeadline};

--- a/crates/rsjudge-traits/src/judger.rs
+++ b/crates/rsjudge-traits/src/judger.rs
@@ -2,11 +2,15 @@
 
 //! Abstraction for judger.
 
-use std::{future::Future, path::Path, process::Output, time::Duration};
+use std::future::Future;
+use std::path::Path;
+use std::process::Output;
+use std::time::Duration;
 
 use indexmap::IndexMap;
 
-use crate::language::{info::LanguageInfo, option::LanguageOption};
+use crate::language::info::LanguageInfo;
+use crate::language::option::LanguageOption;
 
 /// A trait for judging code.
 pub trait Judger {

--- a/crates/rsjudge-traits/src/language/config.rs
+++ b/crates/rsjudge-traits/src/language/config.rs
@@ -69,7 +69,9 @@ pub enum ConfigDef {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, fs::File, io::Read};
+    use std::collections::HashMap;
+    use std::fs::File;
+    use std::io::Read;
 
     use indexmap::{IndexMap, indexmap};
     use toml::toml;

--- a/crates/rsjudge-traits/src/lib.rs
+++ b/crates/rsjudge-traits/src/lib.rs
@@ -9,7 +9,5 @@ pub mod language;
 pub mod resource;
 pub mod service;
 
-pub use crate::{
-    judger::Judger,
-    service::{Service, ServiceConfig},
-};
+pub use crate::judger::Judger;
+pub use crate::service::{Service, ServiceConfig};

--- a/crates/rsjudge-traits/src/resource.rs
+++ b/crates/rsjudge-traits/src/resource.rs
@@ -2,7 +2,8 @@
 
 //! Resource limit for judging code.
 
-use std::{num::NonZeroU64, time::Duration};
+use std::num::NonZeroU64;
+use std::time::Duration;
 
 /// Resource limit for judging code.
 #[derive(Debug, Default, Clone, Copy)]

--- a/crates/rsjudge-traits/src/service.rs
+++ b/crates/rsjudge-traits/src/service.rs
@@ -2,7 +2,8 @@
 
 //! Abstraction for services.
 
-use std::{error::Error, future::Future};
+use std::error::Error;
+use std::future::Future;
 
 use serde::de::DeserializeOwned;
 

--- a/crates/rsjudge-utils/src/command.rs
+++ b/crates/rsjudge-utils/src/command.rs
@@ -2,11 +2,9 @@
 
 //! Functions for working with [`tokio::process::Command`].
 
-use std::{
-    io::{self, ErrorKind},
-    iter,
-    process::{ExitStatus, Output, Stdio},
-};
+use std::io::{self, ErrorKind};
+use std::iter;
+use std::process::{ExitStatus, Output, Stdio};
 
 use thiserror::Error;
 use tokio::process::Command;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,6 +2,6 @@
 
 edition = "2024"
 group_imports = "StdExternalCrate"
-imports_granularity = "Crate"
+imports_granularity = "Module"
 unstable_features = true
 wrap_comments = true

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,10 +3,8 @@
 use std::io::Write as _;
 
 use chrono::{Local, SubsecRound};
-use env_logger::{
-    Builder, Env,
-    fmt::style::{AnsiColor, Style},
-};
+use env_logger::fmt::style::{AnsiColor, Style};
+use env_logger::{Builder, Env};
 
 pub(crate) fn setup_logger() {
     Builder::from_env(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env::set_current_dir, io, path::Path, process::Command};
+use std::env::set_current_dir;
+use std::io;
+use std::path::Path;
+use std::process::Command;
 
 use clap::{Parser, ValueEnum};
 


### PR DESCRIPTION
`imports_granularity = "Module"` makes it easier to `grep` over code for a symbol using "use crate::module.*item;" or something similar.