### PR TITLE
docs: 📄 specify license in README files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -149,3 +149,8 @@ cargo xtask dist deb
 ----
 
 The `.deb` package will be generated in `target/debian`.
+
+
+== Licensing
+
+rsjudge is a Free/Libre and Open Source Software (FLOSS). All source code is licensed under https://www.apache.org/licenses/LICENSE-2.0[Apache License Version 2.0] (SPDX License Identifier: https://spdx.org/licenses/Apache-2.0.html[Apache-2.0]). You can read the full license text from link:./LICENSE[LICENSE].

--- a/README.zh-CN.adoc
+++ b/README.zh-CN.adoc
@@ -139,3 +139,7 @@ cargo xtask dist deb
 ----
 
 生成的软件包位于 `target/debian` 目录下。
+
+== 许可协议
+
+rsjudge 是自由及开源软件（FLOSS）。所有源码基于 https://www.apache.org/licenses/LICENSE-2.0[Apache 2.0 许可证]（SPDX 协议标识符：https://spdx.org/licenses/Apache-2.0.html[Apache-2.0]）授权。您可以在 link:./LICENSE[LICENSE] 文件中阅读完整的协议文本。


### PR DESCRIPTION
Previously, the license was not specified in README. In this PR, a "Licensing" part is added to both [English](https://github.com/NJUPT-SAST/rsjudge/blob/09c914a4993c50b14b42055dfd18cc671a981000/README.adoc#licensing) and [Chinese](https://github.com/NJUPT-SAST/rsjudge/blob/09c914a4993c50b14b42055dfd18cc671a981000/README.zh-CN.adoc#%E8%AE%B8%E5%8F%AF%E5%8D%8F%E8%AE%AE) version.