### PR TITLE
Replace arduino/setup-protoc with Jisu-Woniu/setup-protoc

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -56,10 +56,7 @@ jobs:
       - name: Setup mold
         uses: rui314/setup-mold@v1
       - name: Setup protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: v31.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: Jisu-Woniu/setup-protoc@v1
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
       - name: Enable sccache
@@ -114,10 +111,7 @@ jobs:
         with:
           setup_only: true
       - name: Setup protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: v31.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: Jisu-Woniu/setup-protoc@v1
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
       - name: Enable sccache
@@ -159,10 +153,7 @@ jobs:
         with:
           setup_only: true
       - name: Setup protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: v31.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: Jisu-Woniu/setup-protoc@v1
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
       - name: Enable sccache
@@ -209,10 +200,7 @@ jobs:
         with:
           setup_only: true
       - name: Setup protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: v31.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: Jisu-Woniu/setup-protoc@v1
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
       - name: Check for MSRV compliance
@@ -251,10 +239,7 @@ jobs:
         with:
           setup_only: true
       - name: Setup protoc
-        uses: arduino/setup-protoc@master
-        with:
-          version: v31.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: Jisu-Woniu/setup-protoc@v1
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
       - name: Enable sccache


### PR DESCRIPTION
The original [arduino/setup-protoc](https://github.com/arduino/setup-protoc) cannot handle latest protoc version automatically. I made a rewrite of it and introduced it as an experiment.